### PR TITLE
WAZO-1672-deindent-https-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 .tox
 .coverage
 coverage.xml
-nosetests.xml
 pycodestyle.txt
 pylint.txt
+unit-tests.xml

--- a/etc/wazo-amid/config.yml
+++ b/etc/wazo-amid/config.yml
@@ -54,19 +54,15 @@ bus:
 
 # REST API server
 rest_api:
+  # Listening address
+  listen: 0.0.0.0
 
-  # HTTPS config
-  https:
+  # Listening port
+  port: 9491
 
-    # Listening address
-    listen: 0.0.0.0
-
-    # Listening port
-    port: 9491
-
-    # SSL files
-    certificate: /usr/share/xivo-certs/server.crt
-    private_key: /usr/share/xivo-certs/server.key
+  # SSL files
+  certificate: /usr/share/xivo-certs/server.crt
+  private_key: /usr/share/xivo-certs/server.key
 
   #CORS configuration. See Flask-CORS documentation for other values.
   cors:

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -3,6 +3,6 @@ test-setup:
 	docker build --no-cache -t wazo-amid-tests -f Dockerfile ..
 
 test:
-	nosetests
+	pytest
 
 .PHONY: test-setup test

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -13,10 +13,7 @@ services:
       - "../..:/usr/src/wazo-amid"
       - "./ssl/wazo-auth:/usr/local/share/wazo-auth-ssl"
       - "./ssl/localhost:/usr/local/share/wazo-amid-ssl"
-      - "./etc/wazo-amid/conf.d/disable-ami-events.yml:/etc/wazo-amid/conf.d/disable-ami-events.yml"
-      - "./etc/wazo-amid/conf.d/ajam.yml:/etc/wazo-amid/conf.d/ajam.yml"
-      - "./etc/wazo-amid/conf.d/auth.yml:/etc/wazo-amid/conf.d/auth.yml"
-      - "./etc/wazo-amid/conf.d/rest-api.yml:/etc/wazo-amid/conf.d/rest-api.yml"
+      - "./etc/wazo-amid/conf.d/50-default.yml:/etc/wazo-amid/conf.d/50-default.yml"
 
   asterisk-ajam:
     image: p0bailey/docker-flask

--- a/integration_tests/assets/etc/wazo-amid/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/50-default.yml
@@ -1,0 +1,17 @@
+auth:
+  host: auth
+  port: 9497
+  verify_certificate: /usr/local/share/wazo-auth-ssl/server.crt
+
+ajam:
+  host: asterisk-ajam
+  port: 5040
+  username: wazo_amid
+  password: opensesame
+  verify_certificate: False
+
+rest_api:
+  certificate: /usr/local/share/wazo-amid-ssl/server.crt
+  private_key: /usr/local/share/wazo-amid-ssl/server.key
+
+publish_ami_events: False

--- a/integration_tests/assets/etc/wazo-amid/conf.d/ajam.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/ajam.yml
@@ -1,6 +1,0 @@
-ajam:
-  host: asterisk-ajam
-  port: 5040
-  username: wazo_amid
-  password: opensesame
-  verify_certificate: False

--- a/integration_tests/assets/etc/wazo-amid/conf.d/asset.no-ssl-certificate.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/asset.no-ssl-certificate.yml
@@ -1,3 +1,2 @@
 rest_api:
-  https:
-    certificate: /missing-certificate.crt
+  certificate: /missing-certificate.crt

--- a/integration_tests/assets/etc/wazo-amid/conf.d/asset.no-ssl-private-key.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/asset.no-ssl-private-key.yml
@@ -1,3 +1,2 @@
 rest_api:
-  https:
-    private_key: /missing-key.key
+  private_key: /missing-key.key

--- a/integration_tests/assets/etc/wazo-amid/conf.d/auth.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/auth.yml
@@ -1,4 +1,0 @@
-auth:
-  host: auth
-  port: 9497
-  verify_certificate: /usr/local/share/wazo-auth-ssl/server.crt

--- a/integration_tests/assets/etc/wazo-amid/conf.d/disable-ami-events.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/disable-ami-events.yml
@@ -1,1 +1,0 @@
-publish_ami_events: False

--- a/integration_tests/assets/etc/wazo-amid/conf.d/rest-api.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/rest-api.yml
@@ -1,4 +1,3 @@
 rest_api:
-  https:
-    certificate: /usr/local/share/wazo-amid-ssl/server.crt
-    private_key: /usr/local/share/wazo-amid-ssl/server.key
+  certificate: /usr/local/share/wazo-amid-ssl/server.crt
+  private_key: /usr/local/share/wazo-amid-ssl/server.key

--- a/integration_tests/assets/etc/wazo-amid/conf.d/rest-api.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/rest-api.yml
@@ -1,3 +1,0 @@
-rest_api:
-  certificate: /usr/local/share/wazo-amid-ssl/server.crt
-  private_key: /usr/local/share/wazo-amid-ssl/server.key

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/wazo-platform/xivo-test-helpers/archive/master.zip
 docker-compose
-nose
 openapi-spec-validator
 pyhamcrest
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[nosetests]
-exclude=integration_tests
-
 [tool:pytest]
 testpaths=wazo_amid

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 mock
-nose
+pytest
 pyhamcrest

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,11 @@ skipsdist = true
 [testenv]
 basepython = python3
 commands =
-    nosetests --cover-package=wazo_amid --with-xunit --with-coverage --cover-xml --cover-erase wazo_amid
+    pytest --junitxml=unit-tests.xml --cov=wazo_amid --cov-report term --cov-report xml:coverage.xml wazo_amid
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
-    coverage
+    pytest-cov
 
 [testenv:pycodestyle]
 # E501: line too long (80 chars)
@@ -43,19 +43,21 @@ passenv =
     WAZO_TEST_DOCKER_OVERRIDE_EXTRA
 commands =
     make test-setup
-    nosetests -v {posargs}
+    pytest {posargs}
 whitelist_externals =
+    make
     sh
 
 [testenv:linters]
 skip_install = true
 basepython = python3
-deps = flake8
-       flake8-colors
-       black
+deps =
+    flake8
+    flake8-colors
+    black
 commands =
-  black --skip-string-normalization --check .
-  flake8
+    black --skip-string-normalization --check .
+    flake8
 
 [flake8]
 # E501: line too long (80 chars)
@@ -64,7 +66,7 @@ exclude = .tox,.eggs,alembic
 show-source = true
 ignore = E501, W503
 max-line-length = 99
-application-import-names = wazo_webhookd
+application-import-names = wazo_amid
 
 [testenv:black]
 skip_install = true

--- a/wazo_amid/ami/tests/test_parser.py
+++ b/wazo_amid/ami/tests/test_parser.py
@@ -6,7 +6,7 @@ import unittest
 
 from hamcrest import assert_that
 from hamcrest import equal_to
-from hamcrest import contains
+from hamcrest import contains_exactly
 from mock import Mock
 
 from wazo_amid.ami.parser import parse_buffer
@@ -112,7 +112,7 @@ class TestParser(unittest.TestCase):
 
         assert_that(
             response_lines,
-            contains(
+            contains_exactly(
                 'Class: default',
                 '	Mode: files',
                 '	Directory: /var/lib/wazo/moh/default',

--- a/wazo_amid/config.py
+++ b/wazo_amid/config.py
@@ -48,12 +48,10 @@ _DEFAULT_CONFIG = {
         'startup_connection_delay': 1,
     },
     'rest_api': {
-        'https': {
-            'listen': '0.0.0.0',
-            'port': 9491,
-            'certificate': '/usr/share/xivo-certs/server.crt',
-            'private_key': '/usr/share/xivo-certs/server.key',
-        },
+        'listen': '0.0.0.0',
+        'port': 9491,
+        'certificate': '/usr/share/xivo-certs/server.crt',
+        'private_key': '/usr/share/xivo-certs/server.key',
         'cors': {'enabled': True, 'allow_headers': ['Content-Type', 'X-Auth-Token']},
     },
 }

--- a/wazo_amid/rest_api.py
+++ b/wazo_amid/rest_api.py
@@ -63,14 +63,13 @@ def load_resources(global_config):
 
 
 def run(config):
-    https_config = config['https']
-    bind_addr = (https_config['listen'], https_config['port'])
+    bind_addr = (config['listen'], config['port'])
 
     wsgi_app = ReverseProxied(ProxyFix(wsgi.WSGIPathInfoDispatcher({'/': app})))
     global wsgi_server
     wsgi_server = wsgi.WSGIServer(bind_addr=bind_addr, wsgi_app=wsgi_app)
     wsgi_server.ssl_adapter = http_helpers.ssl_adapter(
-        https_config['certificate'], https_config['private_key']
+        config['certificate'], config['private_key']
     )
 
     logger.debug(


### PR DESCRIPTION
fix pyhmacrest depcreated notice
use pytest instead nosetest
tests: merge config files
config: remove https indent