### PR TITLE
debian: delete group only if user has group

### DIFF
--- a/debian/wazo-amid.postinst
+++ b/debian/wazo-amid.postinst
@@ -45,7 +45,9 @@ case "$1" in
             ln -sf  /etc/nginx/locations/https-available/$DAEMONNAME \
                     /etc/nginx/locations/https-enabled/$DAEMONNAME
         elif dpkg --compare-versions "${previous_version}" lt '20.05'; then
-            deluser --quiet $USER www-data
+            if getent group www-data | grep -q $USER; then
+                deluser --quiet $USER www-data
+            fi
         fi
 
     ;;


### PR DESCRIPTION
reason: otherwise deluser return error