### PR TITLE
allow to set auth config directly inside auth section

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     volumes:
       - "../..:/usr/src/wazo-amid"
       - "./etc/wazo-amid/conf.d/50-default.yml:/etc/wazo-amid/conf.d/50-default.yml"
-      - "./etc/wazo-amid/key.yml:/etc/wazo-amid/key.yml"
 
   asterisk-ajam:
     image: p0bailey/docker-flask

--- a/integration_tests/assets/etc/wazo-amid/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/50-default.yml
@@ -1,7 +1,8 @@
 auth:
   host: auth
   port: 9497
-  key_file: /etc/wazo-amid/key.yml
+  username: wazo-amid
+  password: opensesame
 
 ajam:
   host: asterisk-ajam

--- a/integration_tests/assets/etc/wazo-amid/key.yml
+++ b/integration_tests/assets/etc/wazo-amid/key.yml
@@ -1,2 +1,0 @@
-service_id: wazo-amid
-service_key: opensesame

--- a/wazo_amid/config.py
+++ b/wazo_amid/config.py
@@ -96,6 +96,9 @@ def _get_cli_config():
 
 
 def _load_key_file(config):
+    if config['auth'].get('username') and config['auth'].get('password'):
+        return {}
+
     key_file = parse_config_file(config['auth']['key_file'])
     return {
         'auth': {


### PR DESCRIPTION
reason: the key_file option is only useful on all-in-one installation.
When the bootstrap script (wazo-auth-keys) need to write file with a
specific permission.
But on container, it's more suitable to have all setting inside
config.yml