### PR TITLE
Pull request for WAZO-2241-optimize-ami-parsing

### DIFF
--- a/wazo_amid/ami/parser.py
+++ b/wazo_amid/ami/parser.py
@@ -55,10 +55,10 @@ def _parse_msg(data, event_callback, response_callback):
     except AMIParsingError:
         raise AMIParsingError('unexpected data: %r' % data)
 
-    if first_header.startswith('Response'):
-        callback = response_callback
-    elif first_header.startswith('Event'):
+    if first_header.startswith('Event'):
         callback = event_callback
+    elif first_header.startswith('Response'):
+        callback = response_callback
     else:
         raise AMIParsingError('unexpected data: %r' % data)
 

--- a/wazo_amid/ami/parser.py
+++ b/wazo_amid/ami/parser.py
@@ -36,18 +36,22 @@ def parse_command_response(raw_buffer):
 def _parse_msg(data, event_callback, response_callback):
     lines = data.decode('utf8', 'replace').split('\r\n')
 
+    headers = {}
+    chan_variables = {}
     try:
         first_header, first_value = _parse_line(lines[0])
 
-        headers = {}
         headers[first_header] = first_value
         for line in lines[1:]:
             header, value = _parse_line(line)
             if header == 'ChanVariable':
                 variable, value = _parse_chan_variable(value)
-                headers.setdefault('ChanVariable', {}).setdefault(variable, value)
+                chan_variables[variable] = value
             else:
                 headers[header] = value
+        if chan_variables:
+            headers['ChanVariable'] = chan_variables
+
     except AMIParsingError:
         raise AMIParsingError('unexpected data: %r' % data)
 

--- a/wazo_amid/ami/parser.py
+++ b/wazo_amid/ami/parser.py
@@ -1,6 +1,7 @@
-# Copyright 2012-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import functools
 import logging
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,7 @@ def _parse_msg(data, event_callback, response_callback):
         callback(first_value, headers.get('ActionID'), dict(headers.items()))
 
 
+@functools.lru_cache(maxsize=8192)
 def _parse_line(line):
     try:
         header, value = line.split(':', 1)
@@ -70,5 +72,6 @@ def _parse_line(line):
     return header, value
 
 
+@functools.lru_cache(maxsize=8192)
 def _parse_chan_variable(chan_variable):
     return chan_variable.split('=', 1)

--- a/wazo_amid/ami/parser.py
+++ b/wazo_amid/ami/parser.py
@@ -69,10 +69,12 @@ def _parse_msg(data, event_callback, response_callback):
 @functools.lru_cache(maxsize=8192)
 def _parse_line(line):
     try:
-        header, value = line.split(':', 1)
+        header, value = line.split(': ', 1)
     except ValueError:
-        raise AMIParsingError()
-    value = value.lstrip()
+        try:
+            header, value = line.split(':', 1)
+        except ValueError:
+            raise AMIParsingError
     return header, value
 
 

--- a/wazo_amid/ami/parser.py
+++ b/wazo_amid/ami/parser.py
@@ -39,10 +39,10 @@ def _parse_msg(data, event_callback, response_callback):
     headers = {}
     chan_variables = {}
     try:
-        first_header, first_value = _parse_line(lines[0])
+        first_header, first_value = _parse_line(lines.pop(0))
 
         headers[first_header] = first_value
-        for line in lines[1:]:
+        for line in lines:
             header, value = _parse_line(line)
             if header == 'ChanVariable':
                 variable, value = _parse_chan_variable(value)


### PR DESCRIPTION
## ami parser: optimize parsing time

How:

* Use LRU cache for AMI line parsing

## ami parser: optimize chan variables parsing

How:

* Reduce the number of conditions by using a dedicated dict

## ami parser: optimize message callback

How:

* Events are much more frequent than Responses. This avoids a condition
check in most cases.