### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -38,7 +38,7 @@ class APIAssetLaunchingTestCase(AssetLaunchingTestCase):
         except NoSuchService:
             return WrongClient('amid')
         return AmidClient(
-            'localhost',
+            '127.0.0.1',
             port=port,
             prefix=None,
             https=False,
@@ -51,7 +51,7 @@ class APIAssetLaunchingTestCase(AssetLaunchingTestCase):
             ajam_port = cls.service_port(5040, 'asterisk-ajam')
         except (NoSuchPort, NoSuchService):
             ajam_port = None
-        return 'https://localhost:{port}'.format(port=ajam_port)
+        return 'https://127.0.0.1:{port}'.format(port=ajam_port)
 
 
 class APIIntegrationTest(unittest.TestCase):

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -18,6 +18,6 @@ logger.setLevel(logging.INFO)
 class TestDocumentation(APIIntegrationTest):
     def test_documentation_errors(self):
         port = APIAssetLaunchingTestCase.service_port(9491, 'amid')
-        api_url = 'http://localhost:{port}/1.0/api/api.yml'.format(port=port)
+        api_url = 'http://127.0.0.1:{port}/1.0/api/api.yml'.format(port=port)
         api = requests.get(api_url, verify=False)
         validate_v2_spec(yaml.safe_load(api.text))


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6