### PR TITLE
Pull request for WAZO-2340-amid-bus-crash

### DIFF
--- a/wazo_amid/ami/parser.py
+++ b/wazo_amid/ami/parser.py
@@ -39,15 +39,15 @@ def _parse_msg(data, event_callback, response_callback):
     try:
         first_header, first_value = _parse_line(lines.pop(0))
         headers = _parse_msg_body(lines, first_header, first_value)
-    except AMIParsingError:
-        raise AMIParsingError('unexpected data: %r' % data)
+    except AMIParsingError as e:
+        raise AMIParsingError('unexpected data: %r. Details: %s' % (data, e))
 
     if first_header.startswith('Event'):
         callback = event_callback
     elif first_header.startswith('Response'):
         callback = response_callback
     else:
-        raise AMIParsingError('unexpected data: %r' % data)
+        raise AMIParsingError('unexpected first header: %r' % data)
 
     if callback:
         callback(first_value, headers.get('ActionID'), dict(headers.items()))
@@ -80,7 +80,7 @@ def _parse_line(line):
         try:
             header, value = line.split(':', 1)
         except ValueError:
-            raise AMIParsingError
+            raise AMIParsingError('unexpected line: %r' % line)
     return header, value
 
 

--- a/wazo_amid/ami/parser.py
+++ b/wazo_amid/ami/parser.py
@@ -86,4 +86,8 @@ def _parse_line(line):
 
 @functools.lru_cache(maxsize=8192)
 def _parse_chan_variable(chan_variable):
-    return chan_variable.split('=', 1)
+    try:
+        variable, value = chan_variable.split('=', 1)
+    except ValueError:
+        raise AMIParsingError('unexpected channel variable: %r' % chan_variable)
+    return variable, value


### PR DESCRIPTION
## ami parser: improve logging


## ami parser: handle events containing newlines

Why:

* This may occurs if a variable contains a new line
* This may also occur in unknown conditions, probably due to too many
events being sent by Asterisk at the same time