### PR TITLE
Wazo-2638: Migration of wazo-agentd from Marshmallow 3.0.0b14 to stable version 3.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ flask-restful==0.3.7
 flask==1.0.2
 itsdangerous==0.24  # from flask
 kombu==4.6.11
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 pyyaml==3.13  # from xivo-lib-python
 requests==2.21.0
 werkzeug==0.14.1

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = py37, pycodestyle, pylint
 skipsdist = true
 
 [testenv]
-basepython = python3
+basepython = python3.7
 commands =
     pytest --junitxml=unit-tests.xml --cov=wazo_amid --cov-report term --cov-report xml:coverage.xml wazo_amid
 deps =

--- a/wazo_amid/resources/action/schema.py
+++ b/wazo_amid/resources/action/schema.py
@@ -1,7 +1,8 @@
 # Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from marshmallow import fields, Schema
+from xivo.mallow import fields
+from xivo.mallow_helpers import Schema
 
 
 class Command(Schema):


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/93