### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pytest
 pyhamcrest

--- a/wazo_amid/ami/tests/test_client.py
+++ b/wazo_amid/ami/tests/test_client.py
@@ -11,8 +11,7 @@ from hamcrest import (
     equal_to,
     instance_of,
 )
-from mock import Mock, patch
-from mock import sentinel
+from unittest.mock import Mock, patch, sentinel
 
 from wazo_amid.ami.client import AMIClient, AMIConnectionError
 

--- a/wazo_amid/ami/tests/test_parser.py
+++ b/wazo_amid/ami/tests/test_parser.py
@@ -7,7 +7,7 @@ import unittest
 from hamcrest import assert_that
 from hamcrest import equal_to
 from hamcrest import contains_exactly
-from mock import Mock
+from unittest.mock import Mock
 
 from wazo_amid.ami.parser import parse_buffer
 from wazo_amid.ami.parser import parse_command_response

--- a/wazo_amid/bin/tests/test_main.py
+++ b/wazo_amid/bin/tests/test_main.py
@@ -1,8 +1,8 @@
 # Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from mock import Mock, patch
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from xivo.chain_map import ChainMap
 from wazo_amid.bin.daemon import main

--- a/wazo_amid/tests/test_facade.py
+++ b/wazo_amid/tests/test_facade.py
@@ -3,15 +3,15 @@
 
 import collections
 import unittest
-
-from hamcrest import assert_that, contains, equal_to
-from mock import (
+from unittest.mock import (
     ANY,
     call,
     Mock,
     patch,
     sentinel,
 )
+
+from hamcrest import assert_that, contains, equal_to
 
 from wazo_amid.ami.client import AMIClient, AMIConnectionError
 from wazo_amid.bus.client import BusClient


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package