### PR TITLE
tests: use until...timeout instead of tries count

### DIFF
--- a/integration_tests/suite/test_authentication.py
+++ b/integration_tests/suite/test_authentication.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
@@ -79,7 +79,7 @@ class TestAuthentication(APIIntegrationTest):
                     ),
                 )
 
-            until.assert_(_amid_returns_503, tries=10)
+            until.assert_(_amid_returns_503, timeout=10)
 
         def _amid_does_not_return_503():
             assert_that(
@@ -87,7 +87,7 @@ class TestAuthentication(APIIntegrationTest):
                 not_(raises(HTTPError)),
             )
 
-        until.assert_(_amid_does_not_return_503, tries=10)
+        until.assert_(_amid_does_not_return_503, timeout=10)
 
     def test_no_auth_server_gives_503(self):
         with self.auth_stopped():

--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -56,7 +56,7 @@ class TestStatusRabbitMQ(APIIntegrationTest):
         requests.post(
             APIAssetLaunchingTestCase.make_send_event_ami_url(), json=FAKE_EVENT
         )
-        until.assert_(assert_status_ok, tries=5, interval=10)
+        until.assert_(assert_status_ok, timeout=64)
 
 
 @pytest.mark.usefixtures('base')


### PR DESCRIPTION
Why:

* Easier to read and understand