### PR TITLE
fix tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py37, pycodestyle, pylint
-skipsdist = true
+skipsdist = false
 
 [testenv]
 basepython = python3.7
@@ -22,7 +22,7 @@ commands =
     -sh -c 'pycodestyle --ignore=E501 wazo_amid > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:pylint]
@@ -32,11 +32,11 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pylint
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:integration]
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements.txt
 changedir = integration_tests
 passenv =
@@ -44,7 +44,7 @@ passenv =
 commands =
     make test-setup
     pytest {posargs}
-whitelist_externals =
+allowlist_externals =
     make
     sh
 


### PR DESCRIPTION
changes:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals