### PR TITLE
Bump mypy pre-commit hook to v1.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.19.1
     hooks:
       - id: mypy
         language_version: "3.11"


### PR DESCRIPTION
Resolves compatibility issues with latest types-setuptools.
See WAZO-4386.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates tooling only.
> 
> - Bumps `mypy` pre-commit hook in `.pre-commit-config.yaml` from `v1.6.1` to `v1.19.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cd421ec17811ecffbd03719da8b4c0f6ac18939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->