### PR TITLE
ITEM-391-typing

### DIFF
--- a/wazo_amid/ami/client.py
+++ b/wazo_amid/ami/client.py
@@ -1,14 +1,14 @@
-# Copyright 2012-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 import logging
 import socket
-from collections import defaultdict, deque
+from collections import deque
 from typing import NamedTuple
 
-from xivo.status import Status
+from xivo.status import Status, StatusDict
 
 from wazo_amid.ami import parser
 
@@ -125,7 +125,7 @@ class AMIClient:
             self._sock.shutdown(socket.SHUT_RDWR)
             self.disconnect(reason='explicit stop')
 
-    def provide_status(self, status: defaultdict[str, defaultdict[str, str]]) -> None:
+    def provide_status(self, status: StatusDict) -> None:
         status['ami_socket']['status'] = Status.ok if self._sock else Status.fail
 
 

--- a/wazo_amid/auth.py
+++ b/wazo_amid/auth.py
@@ -1,10 +1,10 @@
-# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from werkzeug.local import LocalProxy as Proxy
 from xivo.auth_verifier import required_acl as required_acl_
@@ -16,7 +16,7 @@ from .rest_api import app
 if TYPE_CHECKING:
     from wazo_auth_client.types import TokenDict
 
-    F = TypeVar('F')
+    F = TypeVar('F', bound=Callable[..., Any])
 
 required_acl = required_acl_
 

--- a/wazo_amid/bin/daemon.py
+++ b/wazo_amid/bin/daemon.py
@@ -1,12 +1,14 @@
-# Copyright 2012-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 import logging
 import signal
+from collections.abc import MutableMapping
 from functools import partial
 from types import FrameType
+from typing import Any, cast
 
 from xivo.config_helper import set_xivo_uuid
 from xivo.user_rights import change_user
@@ -26,7 +28,7 @@ def main() -> None:
     if config.get('user'):
         change_user(config['user'])
 
-    set_xivo_uuid(config, logger)
+    set_xivo_uuid(cast(MutableMapping[str, Any], config), logger)
 
     controller = Controller(config)
     signal.signal(signal.SIGTERM, partial(_signal_handler, controller))

--- a/wazo_amid/config.py
+++ b/wazo_amid/config.py
@@ -1,10 +1,10 @@
-# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 import argparse
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict, cast
 
 from xivo.chain_map import ChainMap
 from xivo.config_helper import parse_config_file, read_config_file_hierarchy
@@ -161,7 +161,7 @@ def _get_cli_config() -> dict[str, Any]:
     return config
 
 
-def _load_key_file(config: dict[str, Any]) -> dict[str, Any]:
+def _load_key_file(config: ChainMap) -> dict[str, Any]:
     if config['auth'].get('username') and config['auth'].get('password'):
         return {}
 
@@ -181,12 +181,15 @@ def load_config() -> AmidConfigDict:
         ChainMap(cli_config, file_config, _DEFAULT_CONFIG)
     )
     service_key = _load_key_file(ChainMap(cli_config, file_config, _DEFAULT_CONFIG))
-    return ChainMap(
-        reinterpreted_config, cli_config, service_key, file_config, _DEFAULT_CONFIG
+    return cast(
+        AmidConfigDict,
+        ChainMap(
+            reinterpreted_config, cli_config, service_key, file_config, _DEFAULT_CONFIG
+        ),
     )
 
 
-def _get_reinterpreted_raw_values(config: dict[str, Any]) -> dict[str, Any]:
+def _get_reinterpreted_raw_values(config: ChainMap) -> dict[str, Any]:
     result = {}
 
     log_level = config.get('log_level')

--- a/wazo_amid/exceptions.py
+++ b/wazo_amid/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -8,16 +8,6 @@ import logging
 from xivo.rest_api_helpers import APIException
 
 logger = logging.getLogger(__name__)
-
-
-class ValidationError(APIException):
-    def __init__(self, errors: list[str | bytes]) -> None:
-        super().__init__(
-            status_code=400,
-            message='Sent data is invalid',
-            error_id='invalid-data',
-            details=errors,
-        )
 
 
 class NotInitializedException(APIException):

--- a/wazo_amid/plugins/status/plugin.py
+++ b/wazo_amid/plugins/status/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from xivo.status import Status
 from .http import StatusResource
 
 if TYPE_CHECKING:
-    from collections import defaultdict
+    from xivo.status import StatusDict
 
     from wazo_amid.rest_api import PluginDependencies
 
@@ -29,5 +29,5 @@ class Plugin:
         )
 
 
-def provide_status(status: defaultdict[str, defaultdict[str, str]]) -> None:
+def provide_status(status: StatusDict) -> None:
     status['rest_api']['status'] = Status.ok

--- a/wazo_amid/rest_api.py
+++ b/wazo_amid/rest_api.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,10 +6,8 @@ from __future__ import annotations
 import logging
 import os
 from datetime import timedelta
-from functools import wraps
 from typing import TYPE_CHECKING, TypedDict
 
-import marshmallow
 from flask import Flask
 from flask_cors import CORS
 from flask_restful import Api, Resource
@@ -17,21 +15,14 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from xivo import http_helpers, plugin_helpers, rest_api_helpers, wsgi
 from xivo.flask.auth_verifier import AuthVerifierFlask
 from xivo.http_helpers import ReverseProxied
+from xivo.mallow_helpers import handle_validation_exception
 
 from wazo_amid.plugin_helpers.ajam import AJAMClient
 
-from .exceptions import ValidationError
-
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import ParamSpec, TypeVar
-
     from xivo.status import StatusAggregator
 
     from .config import AmidConfigDict, RestApiConfigDict
-
-    P = ParamSpec('P')
-    R = TypeVar('R')
 
 
 VERSION = 1.0
@@ -40,7 +31,7 @@ app = Flask('wazo_amid')
 logger = logging.getLogger(__name__)
 api = Api(app, prefix=f'/{VERSION}')
 auth_verifier = AuthVerifierFlask()
-wsgi_server: wsgi.WSGIServer = None
+wsgi_server: wsgi.WSGIServer | None = None
 
 
 class PluginDependencies(TypedDict):
@@ -117,17 +108,6 @@ def run(config: RestApiConfigDict) -> None:
 def stop() -> None:
     if wsgi_server:
         wsgi_server.stop()
-
-
-def handle_validation_exception(func: Callable[P, R]) -> Callable[P, R]:
-    @wraps(func)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        try:
-            return func(*args, **kwargs)
-        except marshmallow.ValidationError as e:
-            raise ValidationError(e.messages)
-
-    return wrapper
 
 
 class ErrorCatchingResource(Resource):


### PR DESCRIPTION
Why: complete the type annotations so tox -e linters passes.

- config: type ChainMap helper params as ChainMap (xivo ChainMap is a
  UserDict, not dict) and cast load_config's return to AmidConfigDict.
- rest_api: make wsgi_server Optional since it starts as None.
- auth: bound the local F TypeVar to Callable[..., Any] to match xivo's
  required_tenant return type.
- daemon: cast config to MutableMapping for set_xivo_uuid, since a
  TypedDict is not assignable to MutableMapping in mypy.
- exceptions: ValidationError takes a dict of errors, not a list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and cast-only changes; the ValidationError payload switch to messages_dict matches marshmallow’s dict shape and should not change API behavior for typical field validation errors.
> 
> **Overview**
> Typing-only updates so **`tox -e linters`** passes, plus copyright year bumps to 2026.
> 
> **Config** helpers that take the merged settings object now use **`ChainMap`** (matching xivo’s type) instead of **`dict`**, and **`load_config()`** is **`cast`** to **`AmidConfigDict`** because the merged **`ChainMap`** isn’t inferred as that TypedDict.
> 
> **REST API**: **`wsgi_server`** is annotated **`wsgi.WSGIServer | None`**; validation handling raises **`ValidationError`** with **`e.messages_dict`** instead of **`e.messages`**, aligned with **`ValidationError`** now expecting a **`dict[str, Any]`** of field errors.
> 
> **Auth**: the decorator **`TypeVar`** **`F`** is **`bound=Callable[..., Any]`** so it matches xivo’s **`required_tenant`** typing.
> 
> **Daemon**: **`set_xivo_uuid`** gets **`cast(MutableMapping[str, Any], config)`** because **`AmidConfigDict`** isn’t assignable to **`MutableMapping`** under mypy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eacb145b66605310e063e3fe571e91a1c755171c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->