### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.02
 
 * `POST` and `PATCH` request bodies to endpoints accepting JSON payload are systematically parsed as JSON, with or without a proper `Content-Type` header;

--- a/etc/wazo-amid/config.yml
+++ b/etc/wazo-amid/config.yml
@@ -67,7 +67,13 @@ rest_api:
     #Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100

--- a/wazo_amid/config.py
+++ b/wazo_amid/config.py
@@ -47,6 +47,7 @@ class RestApiConfigDict(TypedDict):
     certificate: str | None
     private_key: str | None
     cors: CorsConfigDict
+    min_threads: int
     max_threads: int
 
 
@@ -111,7 +112,8 @@ _DEFAULT_CONFIG: AmidConfigDict = {  # type: ignore
         'certificate': None,
         'private_key': None,
         'cors': {'enabled': True, 'allow_headers': ['Content-Type', 'X-Auth-Token']},
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'enabled_plugins': {
         'api': True,

--- a/wazo_amid/rest_api.py
+++ b/wazo_amid/rest_api.py
@@ -31,7 +31,7 @@ app = Flask('wazo_amid')
 logger = logging.getLogger(__name__)
 api = Api(app, prefix=f'/{VERSION}')
 auth_verifier = AuthVerifierFlask()
-wsgi_server: wsgi.WSGIServer | None = None
+wsgi_server: wsgi.DynamicWSGIServer | None = None
 
 
 class PluginDependencies(TypedDict):
@@ -80,10 +80,11 @@ def run(config: RestApiConfigDict) -> None:
 
     wsgi_app = ReverseProxied(ProxyFix(wsgi.WSGIPathInfoDispatcher({'/': app})))
     global wsgi_server
-    wsgi_server = wsgi.WSGIServer(
+    wsgi_server = wsgi.DynamicWSGIServer(
         bind_addr=bind_addr,
         wsgi_app=wsgi_app,
-        numthreads=config['max_threads'],
+        numthreads=config['min_threads'],
+        max=config['max_threads'],
     )
     if config['certificate'] and config['private_key']:
         logger.warning(


### PR DESCRIPTION
Note: lib-python must be merged first to make linter pass ...(todo: update zuul to use depends-on for typing)

Depends-on: https://github.com/wazo-platform/xivo-dao/pull/350
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request concurrency and connection usage under load; behavior depends on `DynamicWSGIServer` from xivo-lib-python, so mis-tuned min/max could affect capacity or resource use.
> 
> **Overview**
> The REST API WSGI layer switches from a fixed-size `WSGIServer` to **`DynamicWSGIServer`**, so worker threads (and associated DB connections) scale between a floor and a ceiling instead of spawning `max_threads` at startup.
> 
> Configuration adds **`rest_api.min_threads`** (default **10**, kept warm) and redefines **`max_threads`** as the upper bound (sample/default moves from **10** to **100**). Typed defaults in `config.py`, shipped `etc/wazo-amid/config.yml`, and **CHANGELOG 26.08** document the new semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840fec100968844ccaf69bc98f3f5a6b4aeeef97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->