### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 26.08
 
 * New `rest_api.min_threads` option: threads kept ready at all times.

--- a/etc/wazo-amid/config.yml
+++ b/etc/wazo-amid/config.yml
@@ -33,8 +33,7 @@ ajam:
 # Connection info to the authentication server
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
 
 # Connection info to the event bus (AMQP)

--- a/integration_tests/assets/etc/wazo-amid/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-amid/conf.d/50-default.yml
@@ -3,6 +3,8 @@ publish_ami_events: True
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: wazo-amid
   password: opensesame
 

--- a/wazo_amid/config.py
+++ b/wazo_amid/config.py
@@ -92,8 +92,7 @@ _DEFAULT_CONFIG: AmidConfigDict = {  # type: ignore
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-amid-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the service reaches wazo-auth at runtime and depends on coordinated nginx/wazo-auth deployment; mis-ordering breaks all internal authentication.
> 
> **Overview**
> **Internal wazo-auth calls** now target **nginx on `localhost:80`** instead of the wazo-auth process on port **9497**. Python defaults (`wazo_amid/config.py`) and shipped `etc/wazo-amid/config.yml` are both updated so layered config stays consistent.
> 
> The explicit **`prefix: null` default is removed** from Python defaults; `wazo-auth-client` is expected to use `/api/auth` on its own. **Integration test config** pins `port: 9497` and `prefix: null` because those stacks have no nginx.
> 
> Changelog **26.09** documents the new default. This must ship **after** the nginx internal entry point and wazo-auth location changes are deployed, or internal auth requests will fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b056454f295db1b57e68f4e18e6fa8c3f878ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->